### PR TITLE
fix:reduced loads on project page

### DIFF
--- a/src/main/groovy/io/microprofile/ApiProjectHydrated.groovy
+++ b/src/main/groovy/io/microprofile/ApiProjectHydrated.groovy
@@ -1,0 +1,64 @@
+package io.microprofile
+
+import javax.inject.Inject
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.PathParam
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+import java.util.stream.Collectors
+
+@Produces('application/json')
+@Path('/projectHydrated')
+/**
+ * This class will return projects like ApiProject, but the results are fully hydrated (contain children).
+ */
+class ApiProjectHydrated {
+
+    @Inject
+    private ServiceProject srv
+
+    @Inject
+    private ServiceContributor contributorService;
+
+    @GET
+    List<DtoProjectDetail> list() {
+        // listing the available specs
+
+        def projects = srv.getAvailableProjects()
+
+        return projects.stream().map{projectName ->
+                 def project = get(projectName);
+                    project.contributors.each {it.info = contributorService.getContributor(it.login)}
+                return project;
+           }.collect(Collectors.toList());
+    }
+
+    @GET
+    @Path('/{projectName : .+}')
+    DtoProjectDetail get(@PathParam("projectName") String projectName) {
+        return srv.getDetails(projectName)
+    }
+
+    @GET
+    @Path('/page/{resourcePath : .+}')
+    DtoProjectPage getPage(@PathParam("resourcePath") String resourcePath) {
+        def projectName = resourcePath.split('/').take(2).join('/')
+        def projectResource = resourcePath.split('/').drop(2).join('/') ?: null
+        return new DtoProjectPage(
+                content: srv.getProjectPage(projectName, projectResource)
+        )
+    }
+
+    @GET
+    @Path('/raw/{resourcePath : .+}')
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    Response getFile(@PathParam("resourcePath") String resourcePath) {
+        def projectName = resourcePath.split('/').take(2).join('/')
+        def projectResource = resourcePath.split('/').drop(2).join('/') ?: null
+        byte[] data = srv.getRaw(projectName, projectResource)
+        return Response.ok(data).build()
+    }
+
+}

--- a/src/main/groovy/io/microprofile/DtoProjectContributor.groovy
+++ b/src/main/groovy/io/microprofile/DtoProjectContributor.groovy
@@ -8,6 +8,7 @@ import groovy.transform.ToString
 class DtoProjectContributor {
     String login
     int contributions
+    DtoContributorInfo info
 
     boolean equals(o) {
         if (this.is(o)) {

--- a/src/main/groovy/io/microprofile/ServiceGithub.groovy
+++ b/src/main/groovy/io/microprofile/ServiceGithub.groovy
@@ -7,7 +7,9 @@ import org.yaml.snakeyaml.Yaml
 import javax.ejb.Lock
 import javax.ejb.LockType
 import javax.ejb.Singleton
+import javax.imageio.ImageIO
 import javax.inject.Inject
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.text.DateFormat
 import java.text.SimpleDateFormat
@@ -178,10 +180,28 @@ class ServiceGithub {
         return new DtoContributorInfo(
                 login: json.login as String,
                 name: json.name as String,
-                avatar: json.avatar_url as String,
+                avatar: (json.avatar_url) as String,
                 company: json.company as String,
                 location: json.location as String
         )
+    }
+
+    String encode(String avatarUrl) {
+        def data = "data:image/png;base64,";
+        def dataBuffer = new ByteArrayOutputStream();
+
+
+        try {
+            ImageIO.write(ImageIO.read(new URL(avatarUrl)), "png", dataBuffer);
+
+
+            data += Base64.encoder.encodeToString(dataBuffer.toByteArray());
+            return data
+        } catch (Exception e) {
+            Logger.anonymousLogger.log(Level.SEVERE, e.message, e);
+            return "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAQAAABLCVATAAAA6UlEQVRIx2NgGAXDDbAx5DIcZ/gMhMeBLDZyjZFmOM/wHwmeB4qQ5RpUYyBGkeGqXLDWnwwVDBJAWAFkgfi5pBt0AqyxHM4vB/NPkG7QJ7BGKThfCsz/NIAGUc1rVAtsqkU/1RIkFbPIsAXqDOkM84Dp5hE4oB8BWfOAIuqkGCHIUMlwFSPqYfAqUFaQsCFMwBT8CachMPgJqIoJnzGsDDvgir8ybGcoYHBgUGPgAUI1IKuAYRtQFCa/A6gaJ2iHKjrDEM7AjlUFO1DmNFRVO26D7oMVlBEMgBKwuvu4FfwnEQ4hg0bB0AAAZQHj53Lw8aMAAAAASUVORK5CYII="
+        }
+        return "";
     }
 
 }

--- a/src/main/static/assets/scripts/projects.ts
+++ b/src/main/static/assets/scripts/projects.ts
@@ -10,6 +10,9 @@ angular.module('microprofileio-projects', ['microprofileio-contributors', 'micro
                 getProjects: function () {
                     return $http.get('api/project');
                 },
+                getProjectsHydrated: function () {
+                    return $http.get('api/projectHydrated');
+                },
                 getProject: function (configFile) {
                     if (!configFile) {
                         return {
@@ -40,7 +43,7 @@ angular.module('microprofileio-projects', ['microprofileio-contributors', 'micro
             scope: {},
             templateUrl: 'app/templates/dir_projects_projects_shortlist.html',
             controller: ['$scope', '$timeout', 'microprofileioProjectsService', function ($scope, $timeout, projectsService) {
-                projectsService.getProjects().then(function (response) {
+                projectsService.getProjectsHydrated().then(function (response) {
                     $timeout(function () {
                         $scope.$apply(function () {
                             $scope.projects = response.data;
@@ -81,13 +84,7 @@ angular.module('microprofileio-projects', ['microprofileio-contributors', 'micro
             },
             templateUrl: 'app/templates/dir_projects_project_card_contributor.html',
             controller: ['$scope', '$timeout', 'microprofileioContributorsService', function ($scope, $timeout, contributorService) {
-                contributorService.getContributor($scope.contributor.login).then(function (response) {
-                    $timeout(function () {
-                        $scope.$apply(function () {
-                            $scope.contributor = response.data;
-                        });
-                    });
-                });
+                $scope.contributor = $scope.contributor.info;
             }]
         };
     }])
@@ -96,22 +93,16 @@ angular.module('microprofileio-projects', ['microprofileio-contributors', 'micro
         return {
             restrict: 'A',
             scope: {
-                projectName: '='
+                projectData: '='
             },
             templateUrl: 'app/templates/dir_projects_project_card.html',
             controller: ['$scope', '$timeout', 'microprofileioProjectsService', function ($scope, $timeout, projectsService) {
-                projectsService.getProject($scope.projectName).then(function (response) {
-                    $timeout(function () {
-                        $scope.$apply(function () {
-                            let project = response.data;
-                            $scope.project = project;
-                            let normalizeName = (name: String) => {
-                                return name.split(':')[0];
-                            };
-                            $scope.name = project.info.friendlyName ? project.info.friendlyName : normalizeName(project.info.name);
-                        });
-                    });
-                });
+                    let project = $scope.projectData;
+                    $scope.project = project;
+                    let normalizeName = (name: String) => {
+                        return name.split(':')[0];
+                    };
+                    $scope.name = project.info.friendlyName ? project.info.friendlyName : normalizeName(project.info.name);
             }]
         };
     }])

--- a/src/main/static/assets/templates/dir_projects_projects_shortlist.jade
+++ b/src/main/static/assets/templates/dir_projects_projects_shortlist.jade
@@ -1,4 +1,4 @@
 div
   div
     div(ng-repeat="project in projects")
-      div(microprofileio-project-card, data-project-name="project")
+      div(microprofileio-project-card, data-project-data="project")


### PR DESCRIPTION
On the project page we will sometimes have projects or contributors fail to load. This happens because the page currently makes over 100 requests to load the page from the micro profile server and gets blocked by the CDN. This change lowers the number of requests to 1.