### PR TITLE
fix some renders on project pages

### DIFF
--- a/src/main/static/assets/scripts/text_services.ts
+++ b/src/main/static/assets/scripts/text_services.ts
@@ -39,7 +39,7 @@ angular.module('microprofileio-text', [])
                         oldHref = imgPath.join('/') + '/' + oldHref;
                         el.attr('src', '/api/project/raw/' + githubProject + '/' + oldHref);
                     });
-                    return content.html();
+                    return "<div class=\"markdown-body\">" + content.html() + "</div>";
                 }
             };
         }

--- a/src/main/static/bower.json
+++ b/src/main/static/bower.json
@@ -13,7 +13,8 @@
     "ngstorage": "~0.3.11",
     "angular-cookies": "1.6.2",
     "angular-resource": "1.6.2",
-    "lato": "0.3.0"
+    "lato": "0.3.0",
+    "github-markdown-css": "^5.1.0"
   },
   "resolutions": {
     "angular": "1.6.2"

--- a/src/main/static/gulpfile.js
+++ b/src/main/static/gulpfile.js
@@ -22,6 +22,7 @@ gulp.task('css-build', gulpsync.sync(['sass', 'autoprefixer', 'css-concat']));
 gulp.task('css-third-party', function () {
     return gulp.src([
         './bower_components/lato/css/lato.css',
+        './bower_components/github-markdown-css/github-markdown.css',
         './bower_components/normalize-css/normalize.css',
         './bower_components/font-awesome/css/font-awesome.min.css'
     ]).pipe(concat('_.css')).pipe(gulp.dest('../../../target/static-resources/app/third-party/styles/'));

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -46,6 +46,22 @@
     </script>
     <link rel="stylesheet" href="app/third-party/styles/_.css"/>
     <link rel="stylesheet" href="app/styles/_.css"/>
+    <link rel="stylesheet" href="github-markdown.css">
+    <style>
+        .markdown-body {
+            box-sizing: border-box;
+            min-width: 200px;
+            max-width: 980px;
+            margin: 0 auto;
+            padding: 45px;
+        }
+
+        @media (max-width: 767px) {
+            .markdown-body {
+                padding: 15px;
+            }
+        }
+    </style>
     <link rel="icon" href="app/images/favicon.png">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">


### PR DESCRIPTION
This fixes some of the rendering issues on project pages. This PR adds in the github markdown css and wraps documents in a class that is supported by the css. 

Before Patch From https://microprofile.io/project/eclipse/microprofile-fault-tolerance

![image](https://user-images.githubusercontent.com/2413816/156896322-d642b94a-777c-4712-a507-8d0d88639528.png)



After Patch From running locally

![image](https://user-images.githubusercontent.com/2413816/156896318-e1a83f69-0a4c-4ca0-bc42-9791b5f5e63f.png)

